### PR TITLE
Add item icon rendering

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import client from 'gw2api-client';
 import Terminal from './terminal.js';
 import modules from './modules';
+import './static/gw2-console.css';
 
 const api = client();
 
@@ -16,6 +17,22 @@ const settings = {
 
 if (settings.apiKey) {
     api.authenticate(settings.apiKey);
+}
+
+async function renderIcons() {
+    const icons = Array.from(document.querySelectorAll('.item.item-unrendered'));
+    const item_ids = icons.map((element) => (element.attributes['data-item-id'].value)).filter((elem) => (elem && elem != ''));
+    if (item_ids.length == 0) return;
+    const items = await api.items().many(item_ids);
+    items.forEach(({id, icon, rarity, name}) => {
+        const item_containers = document.querySelectorAll(`.item-unrendered.item-${id}`);
+        const item_images = document.querySelectorAll(`.item-unrendered.item-${id} .item-icon`);
+        const item_names = document.querySelectorAll(`.item-unrendered.item-${id} .item-name`);
+        item_containers.forEach((container) => (container.classList.add(rarity.toLowerCase())));
+        item_images.forEach((image) => (image.src = icon));
+        item_names.forEach((item_name) => (item_name.innerHTML = name));
+    });
+    icons.forEach((icon) => (icon.classList.remove('item-unrendered')));
 }
 
 const terminal = new Terminal('terminal', {
@@ -38,8 +55,16 @@ const terminal = new Terminal('terminal', {
             console.log(err);
             return `<span style='color:red;'>${err}</span>`;
         }
+    },
+    after_execute: async function (cmd, args) {
+        await renderIcons();
     }
 });
+
+terminal.renderItem = function(item_id, count = -1, name = '') {
+    const display_count = count != -1 ? `${count} ` : '';
+    return `<span class='item item-${item_id} item-unrendered' data-item-id='${item_id}'><img class='item-icon'/><span class='item-label'><span class='item-count'>${display_count}</span><span class='item-name'>${name}</span></span></span>`;
+};
 
 async function wrapApi(promise) {
     try {

--- a/index.js
+++ b/index.js
@@ -46,7 +46,6 @@ const terminal = new Terminal('terminal', {
                 if (result.then) {
                     result = await result;
                 }
-                result = result.replace(/\n/g, '<br />');
                 return result;
             } else {
                 return false;

--- a/modules/currencies.js
+++ b/modules/currencies.js
@@ -61,7 +61,11 @@ export default class extends ApiModule {
         const currencyTotals = allCurrencies.reduce((counts, {id, count}) => ({ ...counts, [id]: (counts[id] || 0) + count }), currencyCounts);
 
         let result = 'Total Currencies:\n';
-        Object.keys(this.currencies).forEach((currency) => (result += `- ${this.currencies[currency]}: ${currencyTotals[currency]}\n`), this);
+        result += (
+            Object.keys(this.currencies)
+                .map((item) => (this._terminal.renderItem(item, currencyTotals[item], this.currencies[item])))
+        ).map((line) => `- ${line}`).join('\n');
+        result += '\n';
 
         if (verbose === 'verbose') {
             result += '\n= Detailed Breakdown =\n\n';
@@ -72,7 +76,10 @@ export default class extends ApiModule {
                 else result += `${source}:\n`;
                 const items = currencySources[source];
                 const sourceTotals = items.reduce((counts, {id, count}) => ({ ...counts, [id]: (counts[id] || 0) + count }), {});
-                Object.keys(sourceTotals).forEach((currency) => (result += `- ${this.currencies[currency]}: ${sourceTotals[currency]}\n`), this);
+                result += (
+                    Object.keys(sourceTotals)
+                        .map((item) => (this._terminal.renderItem(item, sourceTotals[item], this.currencies[item])))
+                ).map((line) => `- ${line}`).join('\n');
             });
         }
         else {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "css-loader": "^3.2.0",
     "gw2api-client": "^7.1.0",
+    "style-loader": "^1.0.0",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.2.3",
     "webpack-dev-server": "^3.2.1",

--- a/static/gw2-console.css
+++ b/static/gw2-console.css
@@ -1,13 +1,28 @@
+.terminal table.input-line tbody {
+  width: 100%;
+}
+
 .item {
   align-items: center;
   display: inline-flex;
   height: 12pt;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
 }
 
 .item .item-icon {
   margin-right: 4px;
   height: 12pt;
   width: 12pt;
+}
+
+.terminal-line, .input-line {
+  align-content: center;
+  display: flex;
+  height: 12pt;
+  line-height: 12pt;
+  list-style: none;
+  white-space: nowrap;
 }
 
 .legendary { color: #4c139d; }

--- a/static/gw2-console.css
+++ b/static/gw2-console.css
@@ -1,0 +1,20 @@
+.item {
+  align-items: center;
+  display: inline-flex;
+  height: 12pt;
+}
+
+.item .item-icon {
+  margin-right: 4px;
+  height: 12pt;
+  width: 12pt;
+}
+
+.legendary { color: #4c139d; }
+.ascended { color: #fb3e8d; }
+.exotic { color: #ffa405; }
+.rare { color: #fcd00b; }
+.masterwork { color: #1a9306; }
+.fine { color: #62a4da; }
+.basic { color: #fff; }
+.junk { color: #aaa; }

--- a/terminal.js
+++ b/terminal.js
@@ -170,6 +170,14 @@
 				}
 				if (response === false) response = cmd + ': command not found';
 				output(response);
+                                // Additional "after execute" handler for post-processing command output.
+                                for (var index in extensions) {
+                                    var ext = extensions[index];
+                                    if (ext.after_execute) response = ext.after_execute(cmd, args);
+                                    if (response && response.then) {
+                                        await response;
+                                    }
+                                }
 			}
 
 			// Show the command line.

--- a/terminal.js
+++ b/terminal.js
@@ -191,6 +191,7 @@
 		}
 
 		function output(html) {
+                        html = html.split('\n').map((line) => (`<li class='terminal-line'>${line}</li>`)).join('');
 			_output.insertAdjacentHTML('beforeEnd', html);
 			_cmdLine.scrollIntoView();
 		}

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -5,5 +5,13 @@ module.exports = {
     output: {
         filename: 'bundle.js',
         path: path.resolve(__dirname, 'dist')
+    },
+    module: {
+        rules: [
+            {
+                test: /\.css$/,
+                use: ['style-loader', 'css-loader']
+            }
+        ]
     }
 };


### PR DESCRIPTION
This adds the ability to render item icons within command outputs.

During command output, a command can use `this._terminal.renderItem(id[, count, name])` and receive a snippet of HTML to include within command output. This snippet can contain as little as a skeleton of an item icon, or as much as the item's count and name.

To save on API calls, item name, rarity, and icon are not fetched until the command has reached full completion. An `after_execute` hook has been added to the terminal library to facilitate this. When this hook is called, a function will search the DOM for any "unrendered" item icon elements, bulk request all of the pertinent items, and fill in classes and image sources as necessary.

![image](https://i.imgur.com/y4W4jHQ.png)